### PR TITLE
Fix for a command that appears to be broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Starter template to build an onchain react native app with [thirdweb](https://th
 
 ## Installation
 
-Install the template using [thirdweb create](https://portal.thirdweb.com/cli/create)
+Install the template using [thirdweb create](https://portal.thirdweb.com/cli/create) and select the React Native option
 
 ```bash
-  npx thirdweb create app --expo
+  npx thirdweb create app
 ```
 
 ## Get started


### PR DESCRIPTION
The command "npx thirdweb create app --expo" appears to be broken/deprecated, so I submitted a fix for it